### PR TITLE
Added autologin setup support and removed ratpoison

### DIFF
--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -168,7 +168,7 @@ fi
 # Install the necessary dependencies for the RC App
 echo "Installing necessary packages"
 BASE_PACKAGES="mesa-utils libgles2 libegl1-mesa libegl-mesa0 mtdev-tools pmount pv python3-gpiozero"
-X11_PACKAGES="ratpoison xserver-xorg xserver-xorg-legacy xinit"
+X11_PACKAGES="xserver-xorg xserver-xorg-legacy xinit"
 VNC_PACKAGES="x11vnc"
 
 PACKAGES_TO_INSTALL="${BASE_PACKAGES}"
@@ -407,19 +407,10 @@ EOF
 chown $USER:$USER /home/$USER/.bashrc
 
 if [[ $MODE == "X11" ]]; then
-	cat > "/home/$USER/.ratpoisonrc" <<-EOF
-set startupmessage 0
-echo Starting RaceCapture...
-bind q quit
-exec $RC_LAUNCH_COMMAND
-	EOF
-	chown $USER:$USER /home/$USER/.ratpoisonrc
-
-
 	cat > "/home/$USER/.xinitrc" <<-EOF
 #!/bin/sh
 $VNC_CMD
-ratpoison
+$RC_LAUNCH_COMMAND
 	EOF
 	chown $USER:$USER /home/$USER/.xinitrc
 fi

--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 RC_APP_URL=`curl -s https://podium.live/software | grep -Po '(?<=<a href=")[^"]*racecapture_linux_raspberrypi[^"]*.bz2'`
 RC_APP_FILENAME=`basename $RC_APP_URL`
@@ -6,7 +6,7 @@ RPI_MODEL=$(tr -d '\0' </proc/device-tree/model)
 REBOOT_NEEDED=0
 
 function yesno() {
-	whiptail --title "$1" --defaultno --yesno "$2" 20 70 4 3>&1 1>&2 2>&3
+	whiptail --title "$1" --yesno "$2" 20 70 4 3>&1 1>&2 2>&3
 	exitstatus=$?
 	# Invert truthines
 	if [ $exitstatus = 0 ]; then
@@ -64,7 +64,15 @@ else
 		if grep -q "^gpu_mem=" /boot/config.txt; then
 			sed -i '$s/^gpu_mem=.*/gpu_mem=256/' /boot/cmdline.txt
 		else
-		       	echo "gpu_mem=256" >> /boot/config.txt
+			echo "gpu_mem=256" >> /boot/config.txt
+		fi
+	fi
+
+	IS_AUTOLOGIN=$(/usr/bin/raspi-config nonint get_autologin)
+	if [[ $IS_AUTOLOGIN == "1" ]]; then
+		ENABLE_AUTOLOGIN=$(yesno "Auto Login" "Enable automatic login on startup?")
+		if [[ $ENABLE_AUTOLOGIN == "1" ]]; then
+			/usr/bin/raspi-config nonint do_boot_behaviour B2
 		fi
 	fi
 

--- a/src/rcdash_setup_template
+++ b/src/rcdash_setup_template
@@ -168,7 +168,7 @@ fi
 # Install the necessary dependencies for the RC App
 echo "Installing necessary packages"
 BASE_PACKAGES="mesa-utils libgles2 libegl1-mesa libegl-mesa0 mtdev-tools pmount pv python3-gpiozero"
-X11_PACKAGES="ratpoison xserver-xorg xserver-xorg-legacy xinit"
+X11_PACKAGES="xserver-xorg xserver-xorg-legacy xinit"
 VNC_PACKAGES="x11vnc"
 
 PACKAGES_TO_INSTALL="${BASE_PACKAGES}"
@@ -316,12 +316,6 @@ EOF
 chown $USER:$USER /home/$USER/.bashrc
 
 if [[ $MODE == "X11" ]]; then
-	cat > "/home/$USER/.ratpoisonrc" <<-EOF
-	__RATPOISON_RC__
-	EOF
-	chown $USER:$USER /home/$USER/.ratpoisonrc
-
-
 	cat > "/home/$USER/.xinitrc" <<-EOF
 	__XINIT_RC__
 	EOF

--- a/src/rcdash_setup_template
+++ b/src/rcdash_setup_template
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 RC_APP_URL=`curl -s https://podium.live/software | grep -Po '(?<=<a href=")[^"]*racecapture_linux_raspberrypi[^"]*.bz2'`
 RC_APP_FILENAME=`basename $RC_APP_URL`
@@ -6,7 +6,7 @@ RPI_MODEL=$(tr -d '\0' </proc/device-tree/model)
 REBOOT_NEEDED=0
 
 function yesno() {
-	whiptail --title "$1" --defaultno --yesno "$2" 20 70 4 3>&1 1>&2 2>&3
+	whiptail --title "$1" --yesno "$2" 20 70 4 3>&1 1>&2 2>&3
 	exitstatus=$?
 	# Invert truthines
 	if [ $exitstatus = 0 ]; then
@@ -64,7 +64,15 @@ else
 		if grep -q "^gpu_mem=" /boot/config.txt; then
 			sed -i '$s/^gpu_mem=.*/gpu_mem=256/' /boot/cmdline.txt
 		else
-		       	echo "gpu_mem=256" >> /boot/config.txt
+			echo "gpu_mem=256" >> /boot/config.txt
+		fi
+	fi
+
+	IS_AUTOLOGIN=$(/usr/bin/raspi-config nonint get_autologin)
+	if [[ $IS_AUTOLOGIN == "1" ]]; then
+		ENABLE_AUTOLOGIN=$(yesno "Auto Login" "Enable automatic login on startup?")
+		if [[ $ENABLE_AUTOLOGIN == "1" ]]; then
+			/usr/bin/raspi-config nonint do_boot_behaviour B2
 		fi
 	fi
 

--- a/src/xinitrc
+++ b/src/xinitrc
@@ -1,3 +1,3 @@
 #!/bin/sh
 $VNC_CMD
-ratpoison
+$RC_LAUNCH_COMMAND


### PR DESCRIPTION
I figured out how to use raspi-config to query for and setup autologin support.   This will make it consistent with what raspi-config does without having to copy/paste it's code.

I also tested and removed the dependency on ratpoison.  As long as the last executable in the .xinitrc file isn't killed the X server will stay up.  So if the run_racecapture_rpi.sh script is running the watchdog, it'll be able to restart the app if it dies without losing X.

This was tested on a fresh RPi4 installation.