### PR TITLE
Fixed bug with RPi3 prompt and switch to fkms

### DIFF
--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -66,6 +66,7 @@ else
 		else
 			echo "gpu_mem=256" >> /boot/config.txt
 		fi
+		REBOOT_NEEDED=1
 	fi
 
 	IS_AUTOLOGIN=$(/usr/bin/raspi-config nonint get_autologin)
@@ -76,10 +77,10 @@ else
 		fi
 	fi
 
-	if [[ $MODEL == "Raspberry Pi 3"* ]]; then
-		if (whiptail --title "RPi3 Official Display" --yesno "Enable RPi Official touchscreen support?\n\nNote: only select yes if using an LCD display connected directly to your RPI, this will disable HDMI output!" 20 70 4); then
-			if ! grep -q "^dtoverlay=vc4-kms-dsi-7inch" /boot/config.txt; then
-				echo "dtoverlay=vc4-kms-dsi-7inch" >> /boot/cmdline.txt
+	if [[ $RPI_MODEL == "Raspberry Pi 3"* ]]; then
+		if grep -q '^dtoverlay=vc4-kms-v3d\s*$' /boot/config.txt; then
+			if (whiptail --title "RPi3 Official Display" --yesno "Enable RPi Official touchscreen support?\n\nNote: only select yes if using an LCD display connected directly to your RPI!" 20 70 4); then
+				sed -i 's/^dtoverlay=vc4-kms-v3d\s*$/dtoverlay=vc4-fkms-v3d/' /boot/config.txt
 				REBOOT_NEEDED=1
 			fi
 		fi

--- a/src/rcdash_setup_template
+++ b/src/rcdash_setup_template
@@ -66,6 +66,7 @@ else
 		else
 			echo "gpu_mem=256" >> /boot/config.txt
 		fi
+		REBOOT_NEEDED=1
 	fi
 
 	IS_AUTOLOGIN=$(/usr/bin/raspi-config nonint get_autologin)
@@ -76,10 +77,10 @@ else
 		fi
 	fi
 
-	if [[ $MODEL == "Raspberry Pi 3"* ]]; then
-		if (whiptail --title "RPi3 Official Display" --yesno "Enable RPi Official touchscreen support?\n\nNote: only select yes if using an LCD display connected directly to your RPI, this will disable HDMI output!" 20 70 4); then
-			if ! grep -q "^dtoverlay=vc4-kms-dsi-7inch" /boot/config.txt; then
-				echo "dtoverlay=vc4-kms-dsi-7inch" >> /boot/cmdline.txt
+	if [[ $RPI_MODEL == "Raspberry Pi 3"* ]]; then
+		if grep -q '^dtoverlay=vc4-kms-v3d\s*$' /boot/config.txt; then
+			if (whiptail --title "RPi3 Official Display" --yesno "Enable RPi Official touchscreen support?\n\nNote: only select yes if using an LCD display connected directly to your RPI!" 20 70 4); then
+				sed -i 's/^dtoverlay=vc4-kms-v3d\s*$/dtoverlay=vc4-fkms-v3d/' /boot/config.txt
 				REBOOT_NEEDED=1
 			fi
 		fi


### PR DESCRIPTION
I was using the wrong variable name for the if block that handles setting up the RPi3.  I fixed that bug and also switched the behavior to use the fkms driver in the case of an RPi3 with official display.  Although the real KMS driver does work, it inconsistently detects and sets up the overlay for the touch screen.  Attempts to force the overlay are also flaking causing the app to fail on a portion of startups due to no /dev/dri directory.

The primary reason to prefer the KMS driver is that all current/future development is happening there and supposedly the KMS driver is already faster than the old code.  But reliability/stability trumps performance in this case.