### PR TITLE
Switch to non-docked keyboard, remove countdown timer.

### DIFF
--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -378,7 +378,7 @@ fi
 
 # Enable virtual keyboard if requeted
 if [[ $ENABLE_TOUCH_KEYBOARD == "1" ]]; then
-       	RC_SCRIPT_ARGS+=" -c kivy:keyboard_mode:systemanddock"
+       	RC_SCRIPT_ARGS+=" -c kivy:keyboard_mode:systemandmulti"
 else
        	RC_SCRIPT_ARGS+=" -c kivy:keyboard_mode:system"
 fi
@@ -394,13 +394,7 @@ fi
 cat > "/home/$USER/.bashrc" <<EOF
 if shopt -q login_shell; then
   if [ -z "\$SSH_CLIENT" ] || [ -z "\$SSH_TTY" ]; then
-    echo "Starting RaceCapture, Ctrl-c to abort!"
-    for i in \$(seq 2 -1 0)
-    do
-      echo -n \$i
-      sleep 1
-      echo -ne '\b'
-    done
+    echo "Starting RaceCapture!"
     $BASH_LAUNCH_CMD
   fi
 fi

--- a/src/bashrc
+++ b/src/bashrc
@@ -1,12 +1,6 @@
 if shopt -q login_shell; then
   if [ -z "\$SSH_CLIENT" ] || [ -z "\$SSH_TTY" ]; then
-    echo "Starting RaceCapture, Ctrl-c to abort!"
-    for i in \$(seq 2 -1 0)
-    do
-      echo -n \$i
-      sleep 1
-      echo -ne '\b'
-    done
+    echo "Starting RaceCapture!"
     $BASH_LAUNCH_CMD
   fi
 fi

--- a/src/rcdash_setup_template
+++ b/src/rcdash_setup_template
@@ -298,7 +298,7 @@ fi
 
 # Enable virtual keyboard if requeted
 if [[ $ENABLE_TOUCH_KEYBOARD == "1" ]]; then
-       	RC_SCRIPT_ARGS+=" -c kivy:keyboard_mode:systemanddock"
+       	RC_SCRIPT_ARGS+=" -c kivy:keyboard_mode:systemandmulti"
 else
        	RC_SCRIPT_ARGS+=" -c kivy:keyboard_mode:system"
 fi


### PR DESCRIPTION
When installing on my own dashboard I noticed that I selected the wrong onscreen keyboard setting.  This causes the keyboard to be rendered partially off screen for some inputs.  Switching to systemandmulti allows you to move the virtual keyboard on the screen.

I also removed the countdown timer in preparation for 2.10 which allows you to exit the watchdog with a graceful shutdown of the app.