### PR TITLE
Escape url entities in download url

### DIFF
--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RC_APP_URL=`curl -s https://podium.live/software | grep -Po '(?<=<a href=")[^"]*racecapture_linux_raspberrypi[^"]*.bz2[^"]*'`
+RC_APP_URL=`curl -s https://podium.live/software | grep -Po '(?<=<a href=")[^"]*racecapture_linux_raspberrypi[^"]*.bz2[^"]*' | python3 -c 'import html, sys; [print(html.unescape(l), end="") for l in sys.stdin]'`
 RC_APP_FILENAME=`basename "$RC_APP_URL" | sed 's/\?.*//'`
 RPI_MODEL=$(tr -d '\0' </proc/device-tree/model)
 SETTINGS_FILE="/home/$SUDO_USER/.config/racecapture/install_settings.cfg"

--- a/src/rcdash_setup_template
+++ b/src/rcdash_setup_template
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RC_APP_URL=`curl -s https://podium.live/software | grep -Po '(?<=<a href=")[^"]*racecapture_linux_raspberrypi[^"]*.bz2[^"]*'`
+RC_APP_URL=`curl -s https://podium.live/software | grep -Po '(?<=<a href=")[^"]*racecapture_linux_raspberrypi[^"]*.bz2[^"]*' | python3 -c 'import html, sys; [print(html.unescape(l), end="") for l in sys.stdin]'`
 RC_APP_FILENAME=`basename "$RC_APP_URL" | sed 's/\?.*//'`
 RPI_MODEL=$(tr -d '\0' </proc/device-tree/model)
 SETTINGS_FILE="/home/$SUDO_USER/.config/racecapture/install_settings.cfg"


### PR DESCRIPTION
This should hopefully fix the download issue.  I'm not sure why it worked before, maybe dropbox was handling it in some way but stopped.