### PR TITLE
Update launch script to reflect new app directory structure

### DIFF
--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -160,7 +160,7 @@ function install_rc_app() {
 }
 
 function install_launcher() {
-	cat > "$LAUNCHER_SCRIPT" <<-EOF
+	cat > "$LAUNCHER_SCRIPT" <<-'EOF'
 #!/bin/bash
 
 # RaceCapture App launch script for Linux

--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -13,6 +13,7 @@ fi
 CONFIG_TXT="$BOOT_BASE/config.txt"
 CMDLINE_TXT="$BOOT_BASE/cmdline.txt"
 #OFFICIAL_DISPLAY=`lsmod | grep -q edt_ft5x06 && echo 1 || echo 0`
+LAUNCHER_SCRIPT="/opt/racecapture/run_racecapture.sh"
 
 function eval_setting() {
 	if [ "$1" == "$2" ]; then
@@ -122,6 +123,68 @@ function add_group() {
 	if ! groups "$USER" | grep -qw "$groupname"; then
 		adduser $USER $groupname
 	fi
+}
+
+function install_launcher() {
+	cat > "$LAUNCHER_SCRIPT" <<-EOF
+#!/bin/bash
+
+# RaceCapture App launch script for Linux
+
+# launch with -w 1 to enable watchdog
+# launch with -l <logfile> to specify the logfile path
+
+
+LOGFILE=~/racecapture.log
+WATCHDOG=0
+
+while getopts ":w:l:" opt; do
+    case ${opt} in
+    w)  WATCHDOG=$OPTARG
+        ;;
+    l)  LOGFILE=$OPTARG
+        ;;
+    esac
+done
+shift $(expr $OPTIND - 1)
+APPARGS=$@
+
+# create the configuration directories as needed
+mkdir -p ~/.kivy
+mkdir -p ~/.config/racecapture
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+# Configure keyring to store Podium user credentials
+export PYTHON_KEYRING_BACKEND=sagecipher.keyring.Keyring
+if [ ! -d "${HOME}/.ssh" ]
+then
+# Create the ssh keys if they don't exist
+cat /dev/zero | ssh-keygen -q -N ""
+fi
+killall ssh-agent &>/dev/null
+eval "$(ssh-agent)" &>/dev/null
+ssh-add &>/dev/null
+
+# run and re-launch if crashed
+while
+  if [ -f $LOGFILE ]; then
+    mv $LOGFILE ${LOGFILE}_last
+  fi
+
+  ./race_capture $APPARGS >> $LOGFILE 2>&1
+
+  exitstatus=$?
+  if [[ $exitstatus -eq 0 || $WATCHDOG -ne 1 ]]; then
+    break
+  fi
+  echo "racecapture crashed with code $?. Restarting..." >> $LOGFILE
+do
+  :
+done
+	EOF
+
 }
 
 function setup_user() {
@@ -477,7 +540,8 @@ ExecStop=/usr/bin/pumount /dev/%I
 	fi
 
 	install_rc_app
-
+    install_launcher
+    
 	RC_SCRIPT_ARGS="-- -c graphics:show_cursor:0"
 	if [[ $MODE == "X11" ]]; then
 		RC_SCRIPT_ARGS+=" --size=$RESOLUTION"
@@ -536,6 +600,7 @@ $RC_LAUNCH_COMMAND
 	dump_settings
 else
 	install_rc_app
+	install_launcher
 fi
 
 echo "Installation complete!!"

--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -506,7 +506,7 @@ ExecStop=/usr/bin/pumount /dev/%I
 		RC_SCRIPT_ARGS+=" -c 'input:%(name)s:'"
 	fi
 	
-	RC_LAUNCH_COMMAND="/opt/racecapture/run_racecapture_rpi.sh $RC_SCRIPT_ARGS"
+	RC_LAUNCH_COMMAND="/opt/racecapture/_internal/run_racecapture_rpi.sh $RC_SCRIPT_ARGS"
 	
 	if [[ $MODE == "X11" ]]; then
 	       	BASH_LAUNCH_CMD="xinit -- -nocursor -dpms -s 0"

--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -12,8 +12,9 @@ else
 fi
 CONFIG_TXT="$BOOT_BASE/config.txt"
 CMDLINE_TXT="$BOOT_BASE/cmdline.txt"
-#OFFICIAL_DISPLAY=`lsmod | grep -q edt_ft5x06 && echo 1 || echo 0`
 LAUNCHER_SCRIPT="/opt/racecapture/run_racecapture_rpi.sh"
+
+#OFFICIAL_DISPLAY=`lsmod | grep -q edt_ft5x06 && echo 1 || echo 0`
 
 function eval_setting() {
 	if [ "$1" == "$2" ]; then
@@ -125,6 +126,39 @@ function add_group() {
 	fi
 }
 
+function setup_user() {
+	# Groups needed for the dietpi user to access opengl, input (touch/mouse) and usb serial ports
+	echo "Adding user to necessary groups"
+	add_group "render"
+	add_group "video"
+	add_group "input"
+	add_group "dialout"
+	
+	# No .config directory can cause RC App to fail
+	mkdir -p /home/$USER/.config/racecapture
+	chown $USER:$USER /home/$USER/.config/racecapture
+	# Create id_rsa if necessary
+	if ! [ -f /home/$USER/.ssh/id_rsa ]; then
+		su -c 'ssh-keygen -b 2048 -t rsa -f /home/$USER/.ssh/id_rsa -q -N ""' - $USER
+	fi
+
+}
+
+function install_rc_app() {
+	# Download and install the RC App
+	RC_APP_URL=`curl -s 'https://podium.live/api/v1/applications/1/latest.json?expand=1&platform=rpi' | jq -r .release.url`
+	RC_APP_FILENAME=`basename "$RC_APP_URL" | sed 's/\?.*//'`
+	echo "Installing RC App '$RC_APP_FILENAME'"
+	if [ -f "$RC_APP_FILENAME" ]; then
+	       	echo "RC App '$RC_APP_FILENAME' already downloaded"
+	else
+	       	echo "Downloading..."
+	       	wget -q --progress=bar --show-progress "$RC_APP_URL" -O "$RC_APP_FILENAME"
+	fi
+
+	dpkg -i $RC_APP_FILENAME
+}
+
 function install_launcher() {
 	cat > "$LAUNCHER_SCRIPT" <<-EOF
 #!/bin/bash
@@ -186,40 +220,6 @@ done
 	EOF
 	chmod +x "$LAUNCHER_SCRIPT"
 }
-
-function setup_user() {
-	# Groups needed for the dietpi user to access opengl, input (touch/mouse) and usb serial ports
-	echo "Adding user to necessary groups"
-	add_group "render"
-	add_group "video"
-	add_group "input"
-	add_group "dialout"
-	
-	# No .config directory can cause RC App to fail
-	mkdir -p /home/$USER/.config/racecapture
-	chown $USER:$USER /home/$USER/.config/racecapture
-	# Create id_rsa if necessary
-	if ! [ -f /home/$USER/.ssh/id_rsa ]; then
-		su -c 'ssh-keygen -b 2048 -t rsa -f /home/$USER/.ssh/id_rsa -q -N ""' - $USER
-	fi
-
-}
-
-function install_rc_app() {
-	# Download and install the RC App
-	RC_APP_URL=`curl -s 'https://podium.live/api/v1/applications/1/latest.json?expand=1&platform=rpi' | jq -r .release.url`
-	RC_APP_FILENAME=`basename "$RC_APP_URL" | sed 's/\?.*//'`
-	echo "Installing RC App '$RC_APP_FILENAME'"
-	if [ -f "$RC_APP_FILENAME" ]; then
-	       	echo "RC App '$RC_APP_FILENAME' already downloaded"
-	else
-	       	echo "Downloading..."
-	       	wget -q --progress=bar --show-progress "$RC_APP_URL" -O "$RC_APP_FILENAME"
-	fi
-
-	dpkg -i $RC_APP_FILENAME
-}
-
 
 if [ -z "$SUDO_USER" ]
 then
@@ -540,8 +540,8 @@ ExecStop=/usr/bin/pumount /dev/%I
 	fi
 
 	install_rc_app
-    install_launcher
-    
+	install_launcher
+
 	RC_SCRIPT_ARGS="-- -c graphics:show_cursor:0"
 	if [[ $MODE == "X11" ]]; then
 		RC_SCRIPT_ARGS+=" --size=$RESOLUTION"

--- a/rcdash_setup.sh
+++ b/rcdash_setup.sh
@@ -13,7 +13,7 @@ fi
 CONFIG_TXT="$BOOT_BASE/config.txt"
 CMDLINE_TXT="$BOOT_BASE/cmdline.txt"
 #OFFICIAL_DISPLAY=`lsmod | grep -q edt_ft5x06 && echo 1 || echo 0`
-LAUNCHER_SCRIPT="/opt/racecapture/run_racecapture.sh"
+LAUNCHER_SCRIPT="/opt/racecapture/run_racecapture_rpi.sh"
 
 function eval_setting() {
 	if [ "$1" == "$2" ]; then
@@ -184,7 +184,7 @@ do
   :
 done
 	EOF
-
+	chmod +x "$LAUNCHER_SCRIPT"
 }
 
 function setup_user() {
@@ -570,7 +570,7 @@ ExecStop=/usr/bin/pumount /dev/%I
 		RC_SCRIPT_ARGS+=" -c 'input:%(name)s:'"
 	fi
 	
-	RC_LAUNCH_COMMAND="/opt/racecapture/_internal/run_racecapture_rpi.sh $RC_SCRIPT_ARGS"
+	RC_LAUNCH_COMMAND="/opt/racecapture/run_racecapture_rpi.sh $RC_SCRIPT_ARGS"
 	
 	if [[ $MODE == "X11" ]]; then
 	       	BASH_LAUNCH_CMD="xinit -- -nocursor -dpms -s 0"

--- a/src/launcher_script
+++ b/src/launcher_script
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# RaceCapture App launch script for Linux
+
+# launch with -w 1 to enable watchdog
+# launch with -l <logfile> to specify the logfile path
+
+
+LOGFILE=~/racecapture.log
+WATCHDOG=0
+
+while getopts ":w:l:" opt; do
+    case ${opt} in
+    w)  WATCHDOG=$OPTARG
+        ;;
+    l)  LOGFILE=$OPTARG
+        ;;
+    esac
+done
+shift $(expr $OPTIND - 1)
+APPARGS=$@
+
+# create the configuration directories as needed
+mkdir -p ~/.kivy
+mkdir -p ~/.config/racecapture
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+# Configure keyring to store Podium user credentials
+export PYTHON_KEYRING_BACKEND=sagecipher.keyring.Keyring
+if [ ! -d "${HOME}/.ssh" ]
+then
+# Create the ssh keys if they don't exist
+cat /dev/zero | ssh-keygen -q -N ""
+fi
+killall ssh-agent &>/dev/null
+eval "$(ssh-agent)" &>/dev/null
+ssh-add &>/dev/null
+
+# run and re-launch if crashed
+while
+  if [ -f $LOGFILE ]; then
+    mv $LOGFILE ${LOGFILE}_last
+  fi
+
+  ./race_capture $APPARGS >> $LOGFILE 2>&1
+
+  exitstatus=$?
+  if [[ $exitstatus -eq 0 || $WATCHDOG -ne 1 ]]; then
+    break
+  fi
+  echo "racecapture crashed with code $?. Restarting..." >> $LOGFILE
+do
+  :
+done

--- a/src/make_rcdash_setup.sh
+++ b/src/make_rcdash_setup.sh
@@ -29,3 +29,6 @@ replace "__BASH_RC__" "bashrc"
 
 replace "__DEFAULT_SETTINGS__" "default_settings"
 replace "__SETTINGS_FILE__" "settings"
+
+# Launcher script
+replace "__LAUNCHER_SCRIPT__" "launcher_script"

--- a/src/make_rcdash_setup.sh
+++ b/src/make_rcdash_setup.sh
@@ -32,3 +32,5 @@ replace "__SETTINGS_FILE__" "settings"
 
 # Launcher script
 replace "__LAUNCHER_SCRIPT__" "launcher_script"
+
+mv rcdash_setup.sh ..

--- a/src/rcdash_setup_template
+++ b/src/rcdash_setup_template
@@ -144,7 +144,7 @@ function install_rc_app() {
 }
 
 function install_launcher() {
-	cat > "$LAUNCHER_SCRIPT" <<-EOF
+	cat > "$LAUNCHER_SCRIPT" <<-'EOF'
 	__LAUNCHER_SCRIPT__
 	EOF
 	chmod +x "$LAUNCHER_SCRIPT"

--- a/src/rcdash_setup_template
+++ b/src/rcdash_setup_template
@@ -12,6 +12,8 @@ else
 fi
 CONFIG_TXT="$BOOT_BASE/config.txt"
 CMDLINE_TXT="$BOOT_BASE/cmdline.txt"
+LAUNCHER_SCRIPT="/opt/racecapture/run_racecapture_rpi.sh"
+
 #OFFICIAL_DISPLAY=`lsmod | grep -q edt_ft5x06 && echo 1 || echo 0`
 
 function eval_setting() {
@@ -141,6 +143,12 @@ function install_rc_app() {
 	dpkg -i $RC_APP_FILENAME
 }
 
+function install_launcher() {
+	cat > "$LAUNCHER_SCRIPT" <<-EOF
+	__LAUNCHER_SCRIPT__
+	EOF
+	chmod +x "$LAUNCHER_SCRIPT"
+}
 
 if [ -z "$SUDO_USER" ]
 then
@@ -381,6 +389,7 @@ if [ "$FULL_INSTALL" = "1" ]; then
 	fi
 
 	install_rc_app
+	install_launcher
 
 	RC_SCRIPT_ARGS="-- -c graphics:show_cursor:0"
 	if [[ $MODE == "X11" ]]; then
@@ -433,6 +442,7 @@ if [ "$FULL_INSTALL" = "1" ]; then
 	dump_settings
 else
 	install_rc_app
+	install_launcher
 fi
 
 echo "Installation complete!!"


### PR DESCRIPTION
Now that we've moved the Rpi build to a GH runner, the debian package is putting all of the app libraries, resources, and scripts within an _internal directory, leaving the race_capture executable in the parent dir. 

The run_racecapture.sh script was also moved into that directory, which breaks the current launch script. 

This update will run the script in the correct directory. 

Side note, I wonder if we should move the run_racecapture.sh script into this repo and leave it out of the app build? that way it could be more self-contained. 

